### PR TITLE
Change hmr server hostname to 0.0.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+  * Change hmr server hostname to 0.0.0.0 so we can use with vagrant/virtualbox
+
 # 2.6.0, 3.1.0 (2016-01-07)
 
   * Allow passing a Javascript file for the `--config` option. This will allow usage of `webpackConfig` outside of using `gulp` or `grunt`

--- a/lib/hmr-server.js
+++ b/lib/hmr-server.js
@@ -19,7 +19,7 @@ module.exports = function (webpackConfig, port, log, distDir) {
     res.sendFile(path.join(distDir, 'index.html'))
   })
 
-  app.listen(port, 'localhost', function (err) {
+  app.listen(port, '0.0.0.0', function (err) {
     if (err) {
       log.error(err)
       return


### PR DESCRIPTION
So we can use with vagrant/virtualbox:
http://stackoverflow.com/questions/27638889/unable-to-connect-to-node-js-in-vagrant