### PR TITLE
Issue 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 styleguide
 rsg-tmp
+.idea

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+  * Filters components without `styleguide` field. Fixes #16: Fails if input files have no styleguide field
+
 # 3.2.1 (2016-01-28)
 
   * patch version bump so npm shows the latest true version

--- a/app/utils/contents.js
+++ b/app/utils/contents.js
@@ -4,7 +4,9 @@ import Components from '../../rsg-tmp/component-requires'
 
 // for `commonStrict` module formatter
 // https://babeljs.io/docs/usage/modules/#interop
-let Contents = Components.map((Content) => Content.default || Content)
+let Contents = Components
+  .map((Content) => Content.default || Content)
+  .filter((Component) => Component.styleguide)
 // compare index numbers
   .sort((a, b) => {
     a = a.styleguide.index


### PR DESCRIPTION
Hey @theogravity 

Inserted a simple filter to exclude components that don't have a `styleguide` field.

We may want to consider changes to `contents.js` so that the nav list can be generated without indexes and categories.  That way you can just point rsg at your components directory and get docs for propTypes. 