### PR TITLE
Fix RSG-alt to work on npm 2.x

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# 3.3.1 (2016-02-16)
+  * Removes 'vendor' feature from webpack config to allow npm2 compatibility.
+
 # 3.3.0 (2016-02-15)
 
   * Bumps Babel to 6.5.2. Fixes #9. No more unnecessary semicolons enforcement.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# 3.4.0 (2016-02-16)
+  * Bumping previous commit to 3.4.0 instead of 3.3.1
+  
 # 3.3.1 (2016-02-16)
   * Removes 'vendor' feature from webpack config to allow npm2 compatibility.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See `HISTORY.md` for future update info
 ## Prereqs
 
 * React 0.14.x. Install both `react` and `react-dom`.
-* Was developed on node 4 w/ npm 3.4. Unsure if older node versions work or not.
+* Was developed on node 4. Unsure if older node versions work or not.
 
 ## Installation
 

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -313,22 +313,7 @@ RSG.prototype.getWebpackConfig = function () {
     entry: {
       app: [path.resolve(__dirname, '../app/index.js')].concat(self.opts.dev ? [
         'webpack-hot-middleware/client'
-      ] : []),
-      vendor: [
-        'redbox-react',
-        'lodash',
-        'react',
-        'react-dom',
-        'react-bootstrap',
-        'react-docgen',
-        'react-simpletabs',
-        'react-transform-hmr',
-        'react-transform-catch-errors',
-        'highlight.js',
-        'immutable',
-        'page',
-        'xtend'
-      ]
+      ] : [])
     },
     output: {
       path: path.join(self.stageDir, 'dist/src'),
@@ -339,10 +324,6 @@ RSG.prototype.getWebpackConfig = function () {
       fs: 'empty'
     },
     plugins: [
-      new webpack.optimize.CommonsChunkPlugin(
-        'vendor',
-        'vendor.bundle.js'
-      ),
       new DocgenPlugin({
         files: self.reactDocGenFiles,
         stageDir: self.stageDir,

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -324,6 +324,10 @@ RSG.prototype.getWebpackConfig = function () {
       fs: 'empty'
     },
     plugins: [
+      new webpack.optimize.CommonsChunkPlugin(
+        'vendor',
+        'vendor.bundle.js'
+      ),
       new DocgenPlugin({
         files: self.reactDocGenFiles,
         stageDir: self.stageDir,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsg-alt",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "A React component guide that generates code examples, prop documentation, rendered component samples and active development.",
   "main": "lib/rsg.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsg-alt",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A React component guide that generates code examples, prop documentation, rendered component samples and active development.",
   "main": "lib/rsg.js",
   "bin": {


### PR DESCRIPTION
Webpack vendor feature breaks on npm 2.x. Reason it works in npm3 is because npm3 creates a flat tree. Taking out the vendor part of the webpack config now allows rsg-alt to work on npm2.x, which is what ships with Node 4.