### PR TITLE
Add support for styleguide.props

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ export default class extends React.Component {
     title: 'Button',
     description: 'You can use **Markdown** within this `description` field.',
     code: `<Button size='small|large' onClick={Function}>Cool Button</Button>`,
-    className: 'apply the css class'
+    className: 'apply the css class',
+    props: {
+      size: 'large'
+    }
   }
 
   onClick () {
@@ -81,6 +84,7 @@ export default class extends React.Component {
 - `description`: Components description (optional)
 - `code`: Code example (optional). Not specifying this will not auto-generate an example.
 - `className`: CSS class name (optional)
+- `props`: Properties to assign to the rendered example component (optional)
 
 #### Additional examples in tabs (optional) [Demo](http://theogravity.github.io/react-styleguide-generator-alt/#!/Features!/Additional%20examples%20in%20tabs)
 

--- a/app/components/Sections/index.js
+++ b/app/components/Sections/index.js
@@ -38,9 +38,11 @@ export default class Sections extends Component {
 
           Content.styleguide._id = i
 
+          const props = { ...this.props, ...Content.styleguide.props }
+
           return (
             <Section {...Content.styleguide} key={i}>
-              {Content.prototype.render && <Content {...this.props} />}
+              {Content.prototype.render && <Content {...props} />}
             </Section>
           )
         })}


### PR DESCRIPTION
- The base example component can now be instantiated with props.

This is useful for components that have required props.

Example:

```
static styleguide = {
  title: 'Button',
  props: {
    size: 'large'
  }
}
```

Closes #22