### PR TITLE
node 0.x compatibility

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# 3.6.0 (2016-05-16)
+  * Expanding backwards compatibility to include node@0.x
+  
 # 3.5.3 (2016-05-09)
   * Adding json-loader to webpack loaders to handle json requires
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See `HISTORY.md` for future update info
 ## Prereqs
 
 * React 0.14.x. Install both `react` and `react-dom`.
-* Was developed on node 4. Unsure if older node versions work or not.
+* Was developed on node 4, but has been known to work on ~0.10.45.
 
 ## Installation
 

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -264,7 +264,11 @@ RSG.prototype.getWebpackConfig = function () {
   var babelLoaderCfg = {
     loader: 'babel-loader',
     query: {
-      presets: ['react', 'es2015', 'stage-0'],
+      presets: [
+        'babel-preset-react',
+        'babel-preset-es2015',
+        'babel-preset-stage-0'
+      ].map(require.resolve),
       plugins: process.env.NODE_ENV === 'development' ? [
         ['react-transform',
           {
@@ -306,7 +310,7 @@ RSG.prototype.getWebpackConfig = function () {
   ]
 
   // custom rule for transpiling files
-  this.opts.transpileIncludes && this.opts.transpileIncludes.forEach((rule) => {
+  this.opts.transpileIncludes && this.opts.transpileIncludes.forEach(function (rule) {
     loaders.push(deepmerge({
       test: /\.jsx?$/,
       include: rule
@@ -326,6 +330,12 @@ RSG.prototype.getWebpackConfig = function () {
     },
     node: {
       fs: 'empty'
+    },
+    resolve: {
+      fallback: path.resolve(__dirname, '../node_modules')
+    },
+    resolveLoader: {
+      root: path.resolve(__dirname, '../node_modules')
     },
     plugins: [
       new webpack.optimize.CommonsChunkPlugin(

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -11,6 +11,7 @@ var hmrServer = require('./hmr-server')
 var DistStyleguidePlugin = require('./webpack-plugins/DistStyleguidePlugin')
 var DocgenPlugin = require('./webpack-plugins/ReactDocgenPlugin')
 var deepmerge = require('deepmerge')
+var Promise = require('promise');
 
 /**
  * React Styleguide Generator

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "style-loader": "^0.13.0",
     "webpack": "^1.12.9",
     "webpack-dev-middleware": "^1.4.0",
-    "webpack-hot-middleware": "^2.6.0"
+    "webpack-hot-middleware": "^2.6.0",
+    "promise": "~7.1.1"
   },
   "devDependencies": {
     "babel-eslint": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsg-alt",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "description": "A React component guide that generates code examples, prop documentation, rendered component samples and active development.",
   "main": "lib/rsg.js",
   "bin": {


### PR DESCRIPTION
This PR makes small changes to expand backwards compatibility for 0.x versions of node.  I have tested this back to 0.10.45, but it may go back further.

This PR will greatly expand the ability for people to use RSG, bumping usage compatibility from 18% to ~100% ([based on stats for node versions deployed to production](https://semaphoreci.com/blog/2015/12/15/nodejs-version-usage-in-commercial-projects-2015-edition.html)).