### PR TITLE
ignoring babelrc for externally used rsg

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
+# UNRELEASED
+  * Preventing .babelrc conflicts with RSG compilation
+
 # 3.6.0 (2016-05-16)
   * Expanding backwards compatibility to include node@0.x
-  
+
 # 3.5.3 (2016-05-09)
   * Adding json-loader to webpack loaders to handle json requires
 

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -299,7 +299,8 @@ RSG.prototype.getWebpackConfig = function () {
     }, babelLoaderCfg),
     deepmerge({
       // for when rsg is included in another project
-      test: /rsg-alt\/app\/(.*)\.js?$/
+      test: /rsg-alt\/app\/(.*)\.js?$/,
+      query: { babelrc: false },
     }, babelLoaderCfg),
     {
       test: /\.css$/,


### PR DESCRIPTION
There is an issue related to #36, where babel automatically merges `.babelrc` configs in any parent directory with the webpack config.  Since this merge is additive, and the deepmerge of the `webpackConfig` is also additive, there is no way to remove presets or plugins from the babel config if they are included in any parent `.babelrc`.  

To fix this problem, I am disabling the search for `babelrc` for files in the RSG directory.