### PR TITLE
fixing publicPath when used with dev server

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+  * Fixes issue where overridden publicPath would break dev mode
+
 # 3.7.0 (2016-05-23)
   * Preventing .babelrc conflicts with RSG compilation
 

--- a/lib/hmr-server.js
+++ b/lib/hmr-server.js
@@ -10,7 +10,7 @@ module.exports = function (webpackConfig, port, log, distDir) {
 
   app.use(require('webpack-dev-middleware')(compiler, {
     colors: true,
-    publicPath: '/src/'
+    publicPath: webpackConfig.publicPath
   }))
 
   app.use(require('webpack-hot-middleware')(compiler))


### PR DESCRIPTION
The value of `webpackConfig.publicPath` can be used in conjunction with the `root` flag to serve the styleguide from a subpath on a domain, but this doesn't work in dev mode because the `publicPath` there was fixed.  This changes it to use the defined value, allowing dev mode to be used at a specific path.

#### Example styleguide.js:
```javascript
var root = 'styleguide';

module.exports = {
    "title": "Some Styleguide",
    "root": root,
    "files": [
        `/${root}/src/extra-styles.css`
    ],
    "webpackConfig": {
        "publicPath": `/${root}/src/`
    }
};
```

