### PR TITLE
Allow additional babelPlugins to be configured

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+  * Allow additional Babel plugins to be configured
+
 # 3.10.0 (2016-06-07)
   * Fixes category navigation when using root or pushstate.
   * Make bundle paths absolute to fix landing on subpaths when using pushstate

--- a/README.md
+++ b/README.md
@@ -376,6 +376,13 @@ Default: `null`
 
 Adds a custom rule(s) to the webpack loader to include additional items to transpile via `babel-loader`. This is provided as a convenience to using `webpackConfig` directly.
 
+#### babelPlugins
+
+Type: `Array<String>`
+Default: `null`
+
+Add Babel plugins in addition to those automatically provided with the presets `react`, `es2015`, `stage-0`. EG: You might want to support decorators with `transform-decorators-legacy`.
+
 ### rsg.generate([callback])
 
 Generate the files and their dependencies into a styleguide output.

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -288,6 +288,10 @@ RSG.prototype.getWebpackConfig = function () {
     }
   }
 
+  if (this.opts.babelPlugins) {
+    babelLoaderCfg.query.plugins = babelLoaderCfg.query.plugins.concat(this.opts.babelPlugins);
+  }
+
   var loaders = [
     {
         test: /\.json/,

--- a/test/rsg.js
+++ b/test/rsg.js
@@ -16,10 +16,7 @@ var TMP_DIR = 'tmp'
 function RSG (input, opts) {
   var baseOpts = {
     output: TMP_DIR,
-    config: null,
-    babelConfig: {
-      stage: 0
-    }
+    config: null
   }
 
   return _RSG(input, assign(baseOpts, opts))
@@ -115,16 +112,16 @@ describe('RSG', function () {
     })
   })
 
-  describe('opts.babelConfig', function () {
+  describe('opts.babelPlugins', function () {
     it('should default to null', function () {
-      var rsg = RSG(INPUT_FILE, { babelConfig: undefined })
-      assert.equal(rsg.opts.babelConfig, null)
+      var rsg = RSG(INPUT_FILE, {})
+      assert.equal(rsg.opts.babelPlugins, null)
     })
 
-    it('should be an object', function () {
-      var babelConfig = { stage: 0 }
-      var rsg = RSG(INPUT_FILE, { babelConfig: babelConfig })
-      assert.deepEqual(rsg.opts.babelConfig, babelConfig)
+    it('should be an array', function () {
+      var babelPlugins = ['transform-decorators-legacy']
+      var rsg = RSG(INPUT_FILE, { babelPlugins: babelPlugins })
+      assert.deepEqual(rsg.opts.babelPlugins, babelPlugins)
     })
   })
 


### PR DESCRIPTION
EG: To support decorators

This serves my needs for now, let me know if you have any different requirements.

Also removed `babelConfig` tests as that seems no longer supported. Also wasn't able to actually run the tests as I got this error:

```standard: Use JavaScript Standard Style (https://github.com/feross/standard)
  /Users/stephencollings/workspace/react-styleguide-generator-alt/lib/rsg.js:14:33: Extra semicolon.
  /Users/stephencollings/workspace/react-styleguide-generator-alt/lib/rsg.js:292:95: Extra semicolon.
  /Users/stephencollings/workspace/react-styleguide-generator-alt/lib/rsg.js:297:9: Expected indentation of 6 space characters but found 8.
  /Users/stephencollings/workspace/react-styleguide-generator-alt/lib/rsg.js:298:9: Expected indentation of 6 space characters but found 8.
  /Users/stephencollings/workspace/react-styleguide-generator-alt/lib/rsg.js:307:32: Unexpected trailing comma.```

Oh, just noticed this related issue https://github.com/theogravity/react-styleguide-generator-alt/issues/36