### PR TITLE
Fixed wrong path to 'publicPath' variable

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,5 @@
+# UNRELEASED
+
 # 3.11.2 (2016-07-01)
   * Fix to render also pure function components
   

--- a/lib/hmr-server.js
+++ b/lib/hmr-server.js
@@ -10,7 +10,7 @@ module.exports = function (webpackConfig, port, log, distDir) {
 
   app.use(require('webpack-dev-middleware')(compiler, {
     colors: true,
-    publicPath: webpackConfig.publicPath
+    publicPath: webpackConfig.output.publicPath
   }))
 
   app.use(require('webpack-hot-middleware')(compiler))


### PR DESCRIPTION
Fixed wrong path to 'publicPath' variable from webpackConfig