### PR TITLE
explicit check for stateless components

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,13 @@
+# UNRELEASED
+  * Fix broken demo issue with optional render for tabbed examples
+  * Provide examples of stateless components and createClass static usage
+
 # 3.12.1 (2016-07-02)
   * Fixed wrong path to 'publicPath' variable from webpackConfig
 
 # 3.11.2 (2016-07-01)
   * Fix to render also pure function components
-  
+
 # 3.11.1 (2016-06-22)
   * Fix coding style violations
   * Fixing all npm modules to specific versions

--- a/app/components/Sections/index.js
+++ b/app/components/Sections/index.js
@@ -39,10 +39,12 @@ export default class Sections extends Component {
           Content.styleguide._id = i
 
           const props = { ...this.props, ...Content.styleguide.props }
+          // Logical fork of stateless function components and other components
+          const stateful = Content.prototype.isReactComponent === Component.prototype.isReactComponent
 
           return (
             <Section {...Content.styleguide} key={i}>
-              {(Content.prototype.render || Content) && <Content {...props} />}
+              {(!stateful || Content.prototype.render && classComponent) && <Content {...props} />}
             </Section>
           )
         })}

--- a/example/components/Features/Stateless function example.js
+++ b/example/components/Features/Stateless function example.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react'
+import { Button } from 'react-bootstrap'
+
+
+function StatelessFunction() {
+  return <Button>Stateless Function Support!</Button>
+}
+
+StatelessFunction.styleguide = {
+  index: '5.3',
+  category: 'Features!',
+  title: 'Stateless function components',
+  code: `<Button>Stateless Function Support!</Button>`
+}
+
+export default StatelessFunction

--- a/example/components/Features/Support for createClass.js
+++ b/example/components/Features/Support for createClass.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Button } from 'react-bootstrap'
+
+export default React.createClass({
+  statics: {
+    styleguide: {
+      index: '5.4',
+      category: 'Features!',
+      title: 'React.createClass Support',
+      code: `<Button>React.createClass Support!</Button>`
+    }
+  },
+
+  render () {
+    return <Button>React.createClass Support!</Button>
+  }
+})


### PR DESCRIPTION
Fixes #62 and documents #53 by explicitly checking for stateless components to have more specific logic around rendering examples.

This also adds examples of stateless and createClass components.