### PR TITLE
Scope json loader to appDir

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+  * scope json loader to appDir
+
 # 3.13.1 (2016-08-17)
   * Updated tabs to use NPM module `react-simpletabs-alt` instead of `github:matthewgertner/react-simpletabs`
     * No change in functionality

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -335,11 +335,11 @@ RSG.prototype.getWebpackConfig = function () {
     }, babelLoaderCfg))
   })
 
-  var entry = [];
+  var entry = []
 
   if (Array.isArray(this.opts.webpackConfig.entry)) {
-    entry = this.opts.webpackConfig.entry;
-    delete this.opts.webpackConfig.entry;
+    entry = this.opts.webpackConfig.entry
+    delete this.opts.webpackConfig.entry
   }
 
   return deepmerge({

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -308,6 +308,7 @@ RSG.prototype.getWebpackConfig = function () {
   var loaders = [
     {
       test: /\.json/,
+      include: [appDir],
       loader: 'json-loader'
     },
     deepmerge({
@@ -333,9 +334,9 @@ RSG.prototype.getWebpackConfig = function () {
       include: rule
     }, babelLoaderCfg))
   })
-  
+
   var entry = [];
-  
+
   if (Array.isArray(this.opts.webpackConfig.entry)) {
     entry = this.opts.webpackConfig.entry;
     delete this.opts.webpackConfig.entry;


### PR DESCRIPTION
The 'included' webpack config does not scope  the json loader to the app dir, which messes up my build process, since my components themselves use json files and therefore the json loader is used twice.

Maybe it would be a good idea to skip all loaders and use them directly while importing files for best interoperability with other configs?

btw: the github_pages branch needs an update 😉 